### PR TITLE
Resolve units using Service Container

### DIFF
--- a/src/Bus/Marshal.php
+++ b/src/Bus/Marshal.php
@@ -4,7 +4,6 @@ namespace Lucid\Bus;
 
 use Exception;
 use ArrayAccess;
-use ReflectionClass;
 use ReflectionParameter;
 
 trait Marshal
@@ -20,17 +19,15 @@ trait Marshal
      */
     protected function marshal($command, ArrayAccess $source, array $extras = [])
     {
-        $injected = [];
-
-        $reflection = new ReflectionClass($command);
-
-        if ($constructor = $reflection->getConstructor()) {
-            $injected = array_map(function ($parameter) use ($command, $source, $extras) {
-                return $this->getParameterValueForCommand($command, $source, $parameter, $extras);
-            }, $constructor->getParameters());
+        $parameters = [];
+        
+        foreach ($source as $name => $parameter) {
+            $parameters[$name] = $parameter;
         }
 
-        return $reflection->newInstanceArgs($injected);
+        $parameters = array_merge($parameters, $extras);
+
+        return app($command, $parameters);
     }
 
     /**


### PR DESCRIPTION
By leveraging Laravel Service Container, we should be able to:

- type-hint dependencies like `Request` in a constructor and have them injected automatically
- swap a unit instance with a mock for more flexible testing

The solution is backward-compatible.

**Notes:** currently, a generic exception `Unable to map {parameter} to {command}` is thrown when incorrect arguments to a unit constructor are provided. This PR removes that exception in favor of Laravel `BindingResolutionException`