### PR TITLE
fix: feature namespace

### DIFF
--- a/src/Finder.php
+++ b/src/Finder.php
@@ -920,6 +920,6 @@ trait Finder
 
     protected function findFeatureTestsRootNamespace()
     {
-        return 'Tests\\Feature';
+        return 'Tests\\Features';
     }
 }


### PR DESCRIPTION
when you create a feature by lucid console, namespace from test is not equal to path. 
namespace use **Feature** and path use **Features**

![image](https://user-images.githubusercontent.com/11076563/133541507-90370f02-d8a5-44e6-8201-a678a0b289ff.png)
