### PR TITLE
Fix `is_file` with null parameter deprecation warning

### DIFF
--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -22,10 +22,10 @@ abstract class RouteServiceProvider extends BaseServiceProvider
      */
     public function loadRoutesFiles($router, $namespace, $pathApi = null, $pathWeb = null)
     {
-        if (is_file($pathApi)) {
+        if (is_string($pathApi) && is_file($pathApi)) {
             $this->mapApiRoutes($router, $namespace, $pathApi);
         }
-        if (is_file($pathWeb)) {
+        if (is_string($pahtWeb) && is_file($pathWeb)) {
             $this->mapWebRoutes($router, $namespace, $pathWeb);
         }
     }


### PR DESCRIPTION
Fix `assing null to parameter #1 ($filename) of type string is deprecated` by checking wether the variable is a string.

Deprecated in PHP8.1