### PR TITLE
Updated test matrix to current versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,26 +18,22 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.0.21, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1]
         stability: [prefer-lowest, prefer-stable]
-        laravel: [5.5, 6.x, 7.x, 8.x]
+        laravel: [6.x, 7.x, 8.x, 9.x]
         exclude:
-          - laravel: 5.5
-            php: 8.0
           - laravel: 6.x
-            php: 7.0.21
-          - laravel: 6.x
-            php: 7.1
+            php: 8.1
           - laravel: 7.x
-            php: 7.0.21
-          - laravel: 7.x
-            php: 7.1
-          - laravel: 8.x
-            php: 7.0.21
-          - laravel: 8.x
-            php: 7.1
+            php: 8.1
           - laravel: 8.x
             php: 7.2
+          - laravel: 9.x
+            php: 7.2
+          - laravel: 9.x
+            php: 7.3
+          - laravel: 9.x
+            php: 7.4
 
     name: L${{ matrix.laravel }} - PHP ${{ matrix.php }} - ${{ matrix.stability }}
 


### PR DESCRIPTION
Test matrix uses a couple of very old version. I left Laravel 6.x und 7x in it, altough they are out of support.

But you should consider dropping support for PHP < 8.0 and <Laravel 8