### PR TITLE
Fix/v10.x

### DIFF
--- a/src/Bus/ServesFeatures.php
+++ b/src/Bus/ServesFeatures.php
@@ -23,6 +23,6 @@ trait ServesFeatures
     {
         event(new FeatureStarted($feature, $arguments));
 
-        return $this->dispatch($this->marshal($feature, new Collection(), $arguments));
+        return $this->dispatchSync($this->marshal($feature, new Collection(), $arguments));
     }
 }

--- a/src/Bus/ServesFeatures.php
+++ b/src/Bus/ServesFeatures.php
@@ -15,14 +15,23 @@ trait ServesFeatures
      * Serve the given feature with the given arguments.
      *
      * @param string $feature
-     * @param array  $arguments
+     * @param array $arguments
      *
      * @return mixed
      */
+
     public function serve($feature, $arguments = [])
     {
+        /**
+         * Laravel change the behaviour of the dispatch after the release of 10.0.0 and we have to explictly handle this run method
+         * https://github.com/laravel/framework/commit/5f61fd1af0fa0b37a8888637578459eae21faeb
+         * @author Nay Thu Khant (naythukhant644@gmail.com)
+         *
+         */
+        $method = App::version() >= "10.0.0" ? "dispatchSync" : "dispatch";
+
         event(new FeatureStarted($feature, $arguments));
 
-        return $this->dispatchSync($this->marshal($feature, new Collection(), $arguments));
+        return $this->{$method}($this->marshal($feature, new Collection(), $arguments));
     }
 }

--- a/src/Bus/ServesFeatures.php
+++ b/src/Bus/ServesFeatures.php
@@ -2,6 +2,7 @@
 
 namespace Lucid\Bus;
 
+use App;
 use Illuminate\Support\Collection;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Lucid\Events\FeatureStarted;

--- a/src/Bus/UnitDispatcher.php
+++ b/src/Bus/UnitDispatcher.php
@@ -35,9 +35,9 @@ trait UnitDispatcher
     public function run($unit, $arguments = [], $extra = [])
     {
         if (is_object($unit) && !App::runningUnitTests()) {
-            $result = $this->dispatch($unit);
+            $result = $this->dispatchSync($unit);
         } elseif ($arguments instanceof Request) {
-            $result = $this->dispatch($this->marshal($unit, $arguments, $extra));
+            $result = $this->dispatchSync($this->marshal($unit, $arguments, $extra));
         } else {
             if (!is_object($unit)) {
                 $unit = $this->marshal($unit, new Collection(), $arguments);
@@ -58,7 +58,7 @@ trait UnitDispatcher
                 );
             }
 
-            $result = $this->dispatch($unit);
+            $result = $this->dispatchSync($unit);
         }
 
         if ($unit instanceof Operation) {

--- a/src/Bus/UnitDispatcher.php
+++ b/src/Bus/UnitDispatcher.php
@@ -26,30 +26,39 @@ trait UnitDispatcher
      * When the $arguments is an instance of Request
      * it will call dispatchFrom instead.
      *
-     * @param mixed                         $unit
+     * @param mixed $unit
      * @param array|\Illuminate\Http\Request $arguments
-     * @param array                          $extra
+     * @param array $extra
      *
      * @return mixed
      */
     public function run($unit, $arguments = [], $extra = [])
     {
+
+        /**
+         * Laravel change the behaviour of the dispatch after the release of 10.0.0 and we have to explictly handle this run method
+         * https://github.com/laravel/framework/commit/5f61fd1af0fa0b37a8888637578459eae21faeb
+         * @author Nay Thu Khant (naythukhant644@gmail.com)
+         *
+         */
+        $method = App::version() >= "10.0.0" ? "dispatchSync" : "dispatch";
+
         if (is_object($unit) && !App::runningUnitTests()) {
-            $result = $this->dispatchSync($unit);
+            $result = $this->{$method}($unit);
         } elseif ($arguments instanceof Request) {
-            $result = $this->dispatchSync($this->marshal($unit, $arguments, $extra));
+            $result = $this->{$method}($this->marshal($unit, $arguments, $extra));
         } else {
             if (!is_object($unit)) {
                 $unit = $this->marshal($unit, new Collection(), $arguments);
 
-                // don't dispatch unit when in tests and have a mock for it.
+                // don't $this->dispatch() unit when in tests and have a mock for it.
             } elseif (App::runningUnitTests() && app(UnitMockRegistry::class)->has(get_class($unit))) {
                 /** @var UnitMock $mock */
                 $mock = app(UnitMockRegistry::class)->get(get_class($unit));
                 $mock->compareTo($unit);
 
                 // Reaching this step confirms that the expected mock is similar to the passed instance, so we
-                // get the unit's mock counterpart to be dispatched. Otherwise, the previous step would
+                // get the unit's mock counterpart to be $this->dispatch()ed. Otherwise, the previous step would
                 // throw an exception when the mock doesn't match the passed instance.
                 $unit = $this->marshal(
                     get_class($unit),
@@ -58,7 +67,7 @@ trait UnitDispatcher
                 );
             }
 
-            $result = $this->dispatchSync($unit);
+            $result = $this->{$method}($unit);
         }
 
         if ($unit instanceof Operation) {
@@ -87,7 +96,7 @@ trait UnitDispatcher
         // instantiate and queue the unit
         $reflection = new ReflectionClass($unit);
         $instance = $reflection->newInstanceArgs($arguments);
-        $instance->onQueue((string) $queue);
+        $instance->onQueue((string)$queue);
 
         return $this->dispatch($instance);
     }


### PR DESCRIPTION
In Laravel 10.x, the flow of dispatch helper function changed a bit and lucid wont be working on it anymore. To solve it, let me create this PR.

- run method of Lucid\Bus\UnitDispatcher.php &
- serve method of Lucid\Bus\ServesFeature.php 

will now be using dispatchSync() not the dispatch() that lucid used previously. 

    
   